### PR TITLE
OP-854: link between health facilities and districts

### DIFF
--- a/src/pickers/HealthFacilityPicker.js
+++ b/src/pickers/HealthFacilityPicker.js
@@ -1,4 +1,4 @@
-import { healthFacilityLabel, LOCATION_SUMMARY_PROJECTION } from "../utils";
+import { healthFacilityLabel } from "../utils";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { useModulesManager, useTranslations, Autocomplete, useGraphqlQuery } from "@openimis/fe-core";

--- a/src/pickers/HealthFacilityPicker.js
+++ b/src/pickers/HealthFacilityPicker.js
@@ -26,10 +26,11 @@ const HealthFacilityPicker = (props) => {
   const userHealthFacility = useSelector((state) => state.loc.userHealthFacilityFullPath);
   const { formatMessage } = useTranslations("location", modulesManager);
   const [searchString, setSearchString] = useState("");
+  const pickedDistrictsUuids = district && district.map((district) => district.uuid);
   const { data, isLoading, error } = useGraphqlQuery(
     `
-    query HealthFacilityPicker ($str: String, $region: String, $district: String, $level: String) {
-      healthFacilities: healthFacilitiesStr(first: 20, str: $str, regionUuid: $region, districtUuid: $district, level: $level) {
+    query HealthFacilityPicker ($str: String, $region: String, $district: [String], $level: String) {
+      healthFacilities: healthFacilitiesStr(first: 20, str: $str, regionUuid: $region, districtsUuids: $district, level: $level) {
         edges {
           node {
             id
@@ -39,13 +40,13 @@ const HealthFacilityPicker = (props) => {
             level
             servicesPricelist{id, uuid}
             itemsPricelist{id, uuid}
-            location {${LOCATION_SUMMARY_PROJECTION.join(",")} parent { ${LOCATION_SUMMARY_PROJECTION.join(",")} }}
+            location {id,uuid,code,name,type parent { id,uuid,code,name,type }}
           }
         }
       }
     }
   `,
-    { level, region: region?.uuid, district: district?.uuid, str: searchString },
+    { level, region: region?.uuid, district: pickedDistrictsUuids, str: searchString },
     { skip: true },
   );
 

--- a/src/pickers/HealthFacilityPicker.js
+++ b/src/pickers/HealthFacilityPicker.js
@@ -1,4 +1,4 @@
-import { healthFacilityLabel } from "../utils";
+import { healthFacilityLabel, LOCATION_SUMMARY_PROJECTION } from "../utils";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { useModulesManager, useTranslations, Autocomplete, useGraphqlQuery } from "@openimis/fe-core";
@@ -40,7 +40,7 @@ const HealthFacilityPicker = (props) => {
             level
             servicesPricelist{id, uuid}
             itemsPricelist{id, uuid}
-            location {id,uuid,code,name,type parent { id,uuid,code,name,type }}
+            location {${LOCATION_SUMMARY_PROJECTION.join(",")} parent { ${LOCATION_SUMMARY_PROJECTION.join(",")} }}
           }
         }
       }


### PR DESCRIPTION
Part of [OP-854](https://openimis.atlassian.net/browse/OP-854), requires [Passing props to the HealthFacilityPicker](https://github.com/openimis/openimis-fe-admin_js/pull/32).

I'm aware about the wrong branch name (should be feature/OP-854) and about a lack of ticket id in the first commit. It's my mistake.