### PR TITLE
Made the accCode field no longer required

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -199,7 +199,7 @@ function formatCatchment(catchment) {
   return `{
     ${!!catchment.id ? `id: ${catchment.id}` : ""}
     locationId: ${decodeId(catchment.location.id)}
-    catchment: ${catchment.catchment}    
+    catchment: ${catchment.catchment}
   }`;
 }
 
@@ -214,12 +214,12 @@ function formatHealthFacilityGQL(hf) {
   return `
     ${hf.uuid !== undefined && hf.uuid !== null ? `uuid: "${hf.uuid}"` : ""}
     code: "${formatGQLString(hf.code)}"
-    accCode: "${formatGQLString(hf.accCode)}"
     name: "${formatGQLString(hf.name)}"
     locationId: ${decodeId(hf.location.id)}
     level: "${hf.level}"
     legalFormId: "${hf.legalForm.code}"
     careType: "${hf.careType}"
+    ${!!hf.accCode ? `accCode: "${hf.accCode}"` : ""}
     ${!!hf.subLevel ? `subLevelId: "${hf.subLevel.code}"` : ""}
     ${!!hf.address ? `address: "${formatGQLString(hf.address)}"` : ""}
     ${!!hf.phone ? `phone: "${formatGQLString(hf.phone)}"` : ""}

--- a/src/components/HealthFacilityForm.js
+++ b/src/components/HealthFacilityForm.js
@@ -30,7 +30,7 @@ class HealthFacilityForm extends Component {
   constructor(props) {
     super(props);
     this.HealthFacilityPriceListsPanel = props.modulesManager.getRef("location.HealthFacilityPriceListsPanel");
-    this.accCodeMandatory = props.modulesManager.getConf("fe-location", "healthFacilityForm.accCodeMandatory", true);
+    this.accCodeMandatory = props.modulesManager.getConf("fe-location", "healthFacilityForm.accCodeMandatory", false);
   }
 
   _newHealthFacility() {

--- a/src/components/HealthFacilityMasterPanel.js
+++ b/src/components/HealthFacilityMasterPanel.js
@@ -19,7 +19,7 @@ class HealthFacilityMasterPanel extends FormPanel {
     super(props);
     this.codeMaxLength = props.modulesManager.getConf("fe-location", "healthFacilityForm.codeMaxLength", 8);
     this.accCodeMaxLength = props.modulesManager.getConf("fe-location", "healthFacilityForm.accCodeMaxLength", 25);
-    this.accCodeMandatory = props.modulesManager.getConf("fe-location", "healthFacilityForm.accCodeMandatory", true);
+    this.accCodeMandatory = props.modulesManager.getConf("fe-location", "healthFacilityForm.accCodeMandatory", false);
   }
 
   updateRegion = (region) => {


### PR DESCRIPTION
The HF accounting code is not a mandatory field in the backend but it was in the frontend. 

I kept the special "mandatoryness" management system that was set up for this field, in case we might need it later for something else, but changed its default value : the accounting code is now by default not mandatory.