### PR TITLE
OTC-744: New action, filter by picked districts

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -127,14 +127,14 @@ export function fetchLocationsStr(mm, level, parent, str, first) {
   return graphql(payload, `LOCATION_LOCATIONS_${level}`);
 }
 
-export function fetchParentLocationsStr(mm, level, parentUuids, str, first) {
-  const types = mm.getConf("fe-location", "Location.types", ["R", "D", "W", "V"]);
-  let filters = [`type: "${types[level]}"`, `str: "${str}"`, first && `first: ${first}`].filter(Boolean);
+export function fetchParentLocationsStr(modulesManager, level, parentUuids, searchString, first) {
+  const types = modulesManager.getConf("fe-location", "Location.types", ["R", "D", "W", "V"]);
+  const filters = [`type: "${types[level]}"`, `str: "${searchString}"`, first && `first: ${first}`].filter(Boolean);
   if (parentUuids) {
     filters.push(`parent_Uuid_In: ["${parentUuids.join('", "')}"]`);
   }
-  let projections = ["id", "uuid", "type", "code", "name", nestParentsProjections(level)];
-  let payload = formatPageQuery("locationsStr", filters, projections);
+  const projections = ["id", "uuid", "type", "code", "name", nestParentsProjections(level)];
+  const payload = formatPageQuery("locationsStr", filters, projections);
   return graphql(payload, `LOCATION_LOCATIONS_${level}`);
 }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -6,7 +6,7 @@ import {
   formatPageQueryWithCount,
   formatGQLString,
   formatMutation,
-  formatJsonField
+  formatJsonField,
 } from "@openimis/fe-core";
 
 import { LOCATION_SUMMARY_PROJECTION, nestParentsProjections } from "./utils";
@@ -24,7 +24,7 @@ export const HEALTH_FACILITY_PICKER_PROJECTION = [
   "level",
   "servicesPricelist{id, uuid}",
   "itemsPricelist{id, uuid}",
-  `location{${LOCATION_SUMMARY_PROJECTION.join(",")}, parent{${LOCATION_SUMMARY_PROJECTION.join(",")}}}`
+  `location{${LOCATION_SUMMARY_PROJECTION.join(",")}, parent{${LOCATION_SUMMARY_PROJECTION.join(",")}}}`,
 ];
 
 function healthFacilityFullPath(key, mm, id) {
@@ -121,6 +121,17 @@ export function fetchLocationsStr(mm, level, parent, str, first) {
   let filters = [`type: "${types[level]}"`, `str: "${str}"`, first && `first: ${first}`].filter(Boolean);
   if (!!parent) {
     filters.push(`parent_Uuid: "${parent.uuid}"`);
+  }
+  let projections = ["id", "uuid", "type", "code", "name", nestParentsProjections(level)];
+  let payload = formatPageQuery("locationsStr", filters, projections);
+  return graphql(payload, `LOCATION_LOCATIONS_${level}`);
+}
+
+export function fetchParentLocationsStr(mm, level, parentUuids, str, first) {
+  const types = mm.getConf("fe-location", "Location.types", ["R", "D", "W", "V"]);
+  let filters = [`type: "${types[level]}"`, `str: "${str}"`, first && `first: ${first}`].filter(Boolean);
+  if (parentUuids) {
+    filters.push(`parent_Uuid_In: ["${parentUuids.join('", "')}"]`);
   }
   let projections = ["id", "uuid", "type", "code", "name", nestParentsProjections(level)];
   let payload = formatPageQuery("locationsStr", filters, projections);

--- a/src/pickers/HealthFacilityPicker.js
+++ b/src/pickers/HealthFacilityPicker.js
@@ -26,7 +26,8 @@ const HealthFacilityPicker = (props) => {
   const userHealthFacility = useSelector((state) => state.loc.userHealthFacilityFullPath);
   const { formatMessage } = useTranslations("location", modulesManager);
   const [searchString, setSearchString] = useState("");
-  const pickedDistrictsUuids = district && district.map((district) => district.uuid);
+  let pickedDistrictsUuids = [];
+  Array.isArray(district) ? pickedDistrictsUuids = district?.map((district) => district?.uuid) : pickedDistrictsUuids.push(district?.uuid);
   const { data, isLoading, error } = useGraphqlQuery(
     `
     query HealthFacilityPicker ($str: String, $region: String, $district: [String], $level: String) {

--- a/src/pickers/LocationPicker.js
+++ b/src/pickers/LocationPicker.js
@@ -6,7 +6,7 @@ import { withTheme, withStyles } from "@material-ui/core/styles";
 import { withModulesManager, combine, useTranslations, useDebounceCb } from "@openimis/fe-core";
 import _debounce from "lodash/debounce";
 import { locationLabel } from "../utils";
-import { fetchLocationsStr, clearLocations } from "../actions";
+import { fetchLocationsStr, clearLocations, fetchParentLocationsStr } from "../actions";
 import _ from "lodash";
 
 const styles = () => ({
@@ -28,6 +28,7 @@ const LocationPicker = (props) => {
     placeholder,
     filterOptions,
     parentLocation,
+    parentLocations,
     required,
     filterSelectedOptions = true,
     withPlaceholder,
@@ -47,7 +48,6 @@ const LocationPicker = (props) => {
     if (!multiple) setOpen(false);
   };
 
-  // Clear locations on unmount to avoid conflicts with RegionPicker & DistrictPicker
   useEffect(() => {
     return () => {
       dispatch(clearLocations(locationLevel));
@@ -60,13 +60,21 @@ const LocationPicker = (props) => {
       !isLoading &&
       searchString.length >= modulesManager.getConf("fe-location", "locationMinCharLookup", 2)
     ) {
-      dispatch(fetchLocationsStr(modulesManager, locationLevel, parentLocation, searchString));
+      if (parentLocations) {
+        dispatch(fetchParentLocationsStr(modulesManager, locationLevel, parentLocations, searchString, 20));
+      } else {
+        dispatch(fetchLocationsStr(modulesManager, locationLevel, parentLocation, searchString));
+      }
     }
-  }, [searchString, parentLocation]);
+  }, [searchString, parentLocation, parentLocations]);
 
   useEffect(() => {
     if (open) {
-      dispatch(fetchLocationsStr(modulesManager, locationLevel, parentLocation, searchString, 20));
+      if (parentLocations) {
+        dispatch(fetchParentLocationsStr(modulesManager, locationLevel, parentLocations, searchString, 20));
+      } else {
+        dispatch(fetchLocationsStr(modulesManager, locationLevel, parentLocation, searchString));
+      }
     } else {
       setSearchString("");
     }


### PR DESCRIPTION
Part of [OTC-744](https://openimis.atlassian.net/browse/OTC-744).

Requires [OTC-744: Removal of EO pickers, inserting villages automatically](https://github.com/openimis/openimis-fe-admin_js/pull/34)

In scope of this PR, new action was implemented. It allows to filter entities by the picked parents.