### PR TITLE
OTC-750: Clearing user reg/dist after logging out

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -16,6 +16,12 @@ export function fetchUserDistricts() {
   return graphql(payload, "LOCATION_USER_DISTRICTS");
 }
 
+export function clearUserDistricts() {
+  return (dispatch) => {
+    dispatch({ type: `LOCATION_USER_DISTRICTS_CLEAR` });
+  };
+}
+
 export const HEALTH_FACILITY_PICKER_PROJECTION = [
   "id",
   "uuid",

--- a/src/components/UserDistrictsLoader.js
+++ b/src/components/UserDistrictsLoader.js
@@ -1,13 +1,14 @@
 import { Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
-import { fetchUserDistricts } from "../actions";
+import { fetchUserDistricts, clearUserDistricts } from "../actions";
 
 class UserDistrictsLoader extends Component {
   componentDidMount() {
-    if (!this.props.userL0s) {
-      this.props.fetchUserDistricts();
-    }
+    this.props.fetchUserDistricts();
+  }
+  componentWillUnmount() {
+    this.props.clearUserDistricts();
   }
   render() {
     return null;
@@ -19,7 +20,7 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({ fetchUserDistricts }, dispatch);
+  return bindActionCreators({ fetchUserDistricts, clearUserDistricts }, dispatch);
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserDistrictsLoader);

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -55,6 +55,12 @@ function reducer(
         userL0s: _.uniqBy(_.map(userL1s, "parent"), "uuid"),
         userL1s,
       };
+    case "LOCATION_USER_DISTRICTS_CLEAR":
+      return {
+        ...state,
+        userL0s: [],
+        userL1s: [],
+      }
     case "LOCATION_USER_HEALTH_FACILITY_FULL_PATH_RESP":
       var userHealthFacilityFullPath = parseData(action.payload.data.healthFacilities)[0];
       return {


### PR DESCRIPTION
[OTC-750](https://openimis.atlassian.net/browse/OTC-750)

In scope of this ticket, I fixed the issue with wrong select options. Now if we log out, user state is being cleared. Appropriate data are going to be fetched when we log in.