### PR TITLE
hotfix/OP-949: Extension of userL0s and userL1s reducer state

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -44,13 +44,10 @@ function reducer(
     submittingMutation: false,
     mutation: {},
     userL0s: [],
-    fetchingUserL0s: false,
-    fetchedUserL0s: false,
-    errorUserL0s: null,
     userL1s: [],
-    fetchingUserL1s: false,
-    fetchedUserL1s: false,
-    errorUserL1s: null,
+    fetchingUserLocation: false,
+    fetchedUserLocation: false,
+    errorUserLocation: null,
   },
   action,
 ) {
@@ -59,13 +56,10 @@ function reducer(
       return {
         ...state,
         userL0s: [],
-        errorUserL0s: null,
-        fetchingUserL0s: true,
-        fetchedUserL0s: false,
         userL1s: [],
-        errorUserL1s: null,
-        fetchingUserL1s: true,
-        fetchedUserL1s: false,
+        errorUserLocation: null,
+        fetchingUserLocation: true,
+        fetchedUserLocation: false,
       };
     case "LOCATION_USER_DISTRICTS_RESP":
       const userL1s = action.payload.data.userDistricts || [];
@@ -73,33 +67,25 @@ function reducer(
       return {
         ...state,
         userL0s: _.uniqBy(_.map(userL1s, "parent"), "uuid"),
-        errorUserL0s: formatGraphQLError(action.payload),
-        fetchingUserL0s: false,
-        fetchedUserL0s: true,
         userL1s,
-        errorUserL1s: formatGraphQLError(action.payload),
-        fetchingUserL1s: false,
-        fetchedUserL1s: true,
+        errorUserLocation: formatGraphQLError(action.payload),
+        fetchingUserLocation: false,
+        fetchedUserLocation: true,
       };
       case "LOCATION_USER_DISTRICTS_ERR":
         return {
           ...state,
-          errorUserL0s: formatServerError(action.payload),
-          fetchingUserL0s: false,
-          errorUserL1s: formatServerError(action.payload),
-          fetchingUserL1s: false,
+          errorUserLocation: formatServerError(action.payload),
+          fetchingUserLocation: false,
         };
     case "LOCATION_USER_DISTRICTS_CLEAR":
       return {
         ...state,
         userL0s: [],
-        errorUserL0s: null,
-        fetchingUserL0s: false,
-        fetchedUserL0s: false,
         userL1s: [],
-        errorUserL1s: null,
-        fetchingUserL1s: false,
-        fetchedUserL1s: false,
+        fetchingUserLocation: false,
+        fetchedUserLocation: false,
+        errorUserLocation: null,
       }
     case "LOCATION_USER_HEALTH_FACILITY_FULL_PATH_RESP":
       var userHealthFacilityFullPath = parseData(action.payload.data.healthFacilities)[0];

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -43,23 +43,63 @@ function reducer(
     errorL3s: null,
     submittingMutation: false,
     mutation: {},
+    userL0s: [],
+    fetchingUserL0s: false,
+    fetchedUserL0s: false,
+    errorUserL0s: null,
+    userL1s: [],
+    fetchingUserL1s: false,
+    fetchedUserL1s: false,
+    errorUserL1s: null,
   },
   action,
 ) {
   switch (action.type) {
+    case "LOCATION_USER_DISTRICTS_REQ":
+      return {
+        ...state,
+        userL0s: [],
+        errorUserL0s: null,
+        fetchingUserL0s: true,
+        fetchedUserL0s: false,
+        userL1s: [],
+        errorUserL1s: null,
+        fetchingUserL1s: true,
+        fetchedUserL1s: false,
+      };
     case "LOCATION_USER_DISTRICTS_RESP":
       const userL1s = action.payload.data.userDistricts || [];
 
       return {
         ...state,
         userL0s: _.uniqBy(_.map(userL1s, "parent"), "uuid"),
+        errorUserL0s: formatGraphQLError(action.payload),
+        fetchingUserL0s: false,
+        fetchedUserL0s: true,
         userL1s,
+        errorUserL1s: formatGraphQLError(action.payload),
+        fetchingUserL1s: false,
+        fetchedUserL1s: true,
       };
+      case "LOCATION_USER_DISTRICTS_ERR":
+        return {
+          ...state,
+          errorUserL0s: formatServerError(action.payload),
+          fetchingUserL0s: false,
+          errorUserL1s: formatServerError(action.payload),
+          fetchingUserL1s: false,
+        };
     case "LOCATION_USER_DISTRICTS_CLEAR":
       return {
         ...state,
         userL0s: [],
+        errorUserL0s: null,
+        fetchingUserL0s: false,
+        fetchedUserL0s: false,
         userL1s: [],
+        errorUserL1s: null,
+        fetchingUserL1s: false,
+        fetchedUserL1s: false,
       }
     case "LOCATION_USER_HEALTH_FACILITY_FULL_PATH_RESP":
       var userHealthFacilityFullPath = parseData(action.payload.data.healthFacilities)[0];


### PR DESCRIPTION
While working on [OP-949](https://openimis.atlassian.net/browse/OP-949), I extended the userL0s and userL1s Redux state. Moreover, I added it to the initial state.

Idea of this improvement was mentioned [here](https://github.com/openimis/openimis-fe-location_js/pull/30), but then it was not the case of the ticket and I didn't want to spend much time on doing it. At the moment, this extension is essential in view of the current task.