### PR TITLE
OTC-883: blinking input styles during validation fix

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -340,3 +340,9 @@ export function locationCodeValidationClear() {
     dispatch({ type: `LOCATION_CODE_FIELDS_VALIDATION_CLEAR` });
   };
 }
+
+export function locationCodeSetValid() {
+  return (dispatch) => {
+    dispatch({ type: `LOCATION_CODE_SET_VALID` });
+  };
+}

--- a/src/components/EditLocationDialog.js
+++ b/src/components/EditLocationDialog.js
@@ -15,7 +15,7 @@ import {
 } from "@material-ui/core";
 
 import { withModulesManager, formatMessage, TextInput, ValidatedTextInput, NumberInput } from "@openimis/fe-core";
-import { locationCodeValidationCheck, locationCodeValidationClear } from "../actions";
+import { locationCodeValidationCheck, locationCodeValidationClear, locationCodeSetValid } from "../actions";
 
 class EditLocationDialog extends Component {
   state = {
@@ -172,6 +172,7 @@ class EditLocationDialog extends Component {
               <ValidatedTextInput
                 action={locationCodeValidationCheck}
                 clearAction={locationCodeValidationClear}
+                setValidAction={locationCodeSetValid}
                 itemQueryIdentifier="locationCode"
                 isValid={isCodeValid}
                 isValidating={isCodeValidating}

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -409,6 +409,18 @@ function reducer(
           },
         },
       };
+    case "LOCATION_CODE_SET_VALID":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          locationCode: {
+            isValidating: false,
+            isValid: true,
+            validationError: null,
+          },
+        },
+      };
     case "LOCATION_MUTATION_REQ":
       return dispatchMutationReq(state, action);
     case "LOCATION_MUTATION_ERR":


### PR DESCRIPTION
Part of [CORE PR](https://github.com/openimis/openimis-fe-core_js/pull/92)

[OTC-883](https://openimis.atlassian.net/browse/OTC-883)

In scope of this ticket, I fixed blinking input styles. I created a new action that sets the validity of the entered code. This solves the problem.

[OTC-883]: https://openimis.atlassian.net/browse/OTC-883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ