### PR TITLE
OTC-884: Disabled save button in HF form fix

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -317,6 +317,12 @@ export function HFCodeValidationCheck(mm, variables) {
   );
 }
 
+export function HFCodeSetValid() {
+  return (dispatch) => {
+    dispatch({ type: `LOCATION_HF_CODE_FIELDS_VALIDATION_SET_VALID` });
+  };
+}
+
 export function HFCodeValidationClear() {
   return (dispatch) => {
     dispatch({ type: `LOCATION_HF_CODE_FIELDS_VALIDATION_CLEAR` });

--- a/src/components/HealthFacilityMasterPanel.js
+++ b/src/components/HealthFacilityMasterPanel.js
@@ -11,7 +11,7 @@ import {
 } from "@openimis/fe-core";
 import { Grid } from "@material-ui/core";
 import { connect } from "react-redux";
-import { HFCodeValidationCheck, HFCodeValidationClear } from "../actions";
+import { HFCodeValidationCheck, HFCodeValidationClear, HFCodeSetValid } from "../actions";
 
 const styles = (theme) => ({
   item: theme.paper.item,
@@ -172,6 +172,7 @@ class HealthFacilityMasterPanel extends FormPanel {
                 validationError={HFCodeValidationError}
                 action={HFCodeValidationCheck}
                 clearAction={HFCodeValidationClear}
+                setValidAction={HFCodeSetValid}
                 module="location"
                 label="location.HealthFacilityForm.code"
                 codeTakenLabel="location.HealthFacilityForm.codeTaken"

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -361,6 +361,18 @@ function reducer(
           },
         },
       };
+    case "LOCATION_HF_CODE_FIELDS_VALIDATION_SET_VALID":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          HFCode: {
+            isValidating: false,
+            isValid: true,
+            validationError: null,
+          },
+        },
+      };
     case "LOCATION_CODE_FIELDS_VALIDATION_REQ":
       return {
         ...state,


### PR DESCRIPTION
[OTC-884](https://openimis.atlassian.net/browse/OTC-884)

In scope of this ticket, I corrected the state of isValid by adding an extra action, which sets the state properly when we're editing a HF code for the first time. Moreover, there was an issue when we paste an invalid HF code and then revert it using CTRL+Z to the valid one, save button was anyway blocked although saving should be possbile. After the fix, it works as intended.

[OTC-884]: https://openimis.atlassian.net/browse/OTC-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ