### PR TITLE
OTC-770: changed location list in catchment panel

### DIFF
--- a/src/components/HealthFacilityCatchmentPanel.js
+++ b/src/components/HealthFacilityCatchmentPanel.js
@@ -169,7 +169,7 @@ class HealthFacilityCatchmentPanel extends FormPanel {
                 fetched={fetchedL0s}
                 error={errorL0s}
                 location={this.state.l0}
-                locations={userRegions}
+                locations={l0s}
                 currentParents={this.state.currentParents}
                 stateLocation={this.state.location}
                 reassign={true}

--- a/src/components/HealthFacilityCatchmentPanel.js
+++ b/src/components/HealthFacilityCatchmentPanel.js
@@ -152,6 +152,7 @@ class HealthFacilityCatchmentPanel extends FormPanel {
       fetchedL3s,
       errorL3s,
       readOnly,
+      userRegions,
     } = this.props;
     const { l0s, l1s, l2s, l3s } = this.state;
     return (
@@ -168,7 +169,7 @@ class HealthFacilityCatchmentPanel extends FormPanel {
                 fetched={fetchedL0s}
                 error={errorL0s}
                 location={this.state.l0}
-                locations={l0s}
+                locations={userRegions}
                 currentParents={this.state.currentParents}
                 stateLocation={this.state.location}
                 reassign={true}
@@ -253,6 +254,7 @@ const mapStateToProps = (state) => ({
   fetchedL3s: state.loc.fetchedL3s,
   l3s: state.loc.l3s,
   errorL3s: state.loc.errorL3s,
+  userRegions: state?.loc?.userL0s,
 });
 
 const mapDispatchToProps = (dispatch) => {

--- a/src/components/HealthFacilityCatchmentPanel.js
+++ b/src/components/HealthFacilityCatchmentPanel.js
@@ -40,6 +40,7 @@ class HealthFacilityCatchmentPanel extends FormPanel {
     l2s: [],
     l3: null,
     l3s: [],
+    userL0s: [],
   };
 
   constructor(props) {
@@ -60,6 +61,7 @@ class HealthFacilityCatchmentPanel extends FormPanel {
         l1s: this.props.l1s,
         l2s: this.props.l2s,
         l3s: this.props.l3s,
+        userL0s: this.props.userL0s,
       });
     } else if (prevState.l0 !== this.state.l0) {
       if (!this.state.l0) {
@@ -152,7 +154,6 @@ class HealthFacilityCatchmentPanel extends FormPanel {
       fetchedL3s,
       errorL3s,
       readOnly,
-      userRegions,
     } = this.props;
     const { l0s, l1s, l2s, l3s } = this.state;
     return (
@@ -169,7 +170,7 @@ class HealthFacilityCatchmentPanel extends FormPanel {
                 fetched={fetchedL0s}
                 error={errorL0s}
                 location={this.state.l0}
-                locations={l0s}
+                locations={this.state.userL0s}
                 currentParents={this.state.currentParents}
                 stateLocation={this.state.location}
                 reassign={true}
@@ -254,7 +255,7 @@ const mapStateToProps = (state) => ({
   fetchedL3s: state.loc.fetchedL3s,
   l3s: state.loc.l3s,
   errorL3s: state.loc.errorL3s,
-  userRegions: state?.loc?.userL0s,
+  userL0s: state.loc.userL0s,
 });
 
 const mapDispatchToProps = (dispatch) => {


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OTC-770

Changes:
- changed location pool in catchment panel to get locations from user's regions

Notes:
I did work with 'l0s' but there was an issue after changes that users like IMIS Administrator with permissions for managing regions and districts has access to all of the locations so this site wasn't working properly since there was common component between locations menu and this catchment panel. Using locations that are attached to the users fixed the problem in catchment panel.
