### PR TITLE
OTC-1027: filter villages by selected or available locations

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -32,17 +32,12 @@ export function filter_location_by_parents(parents_uuid, filters, location_type)
   parents_uuid.forEach(function (location_uuid) {
     if (location_uuid) {
       if (location_type == 'W'){
-
         filters.push(`parent_Parent_Uuid: "${location_uuid}"`);
         return true
-
       }
-        
       else if (location_type == 'V'){
         filters.push(`parent_Parent_Parent_Uuid: "${location_uuid}"`);
-  
         return true
-
       }
     }
   });

--- a/src/actions.js
+++ b/src/actions.js
@@ -28,19 +28,22 @@ function _pageAndEdges(projections) {
     }`;
 }
 
-export function filter_location_by_parents(parents_uuid, filters, location_type) {
-  parents_uuid.forEach(function (location_uuid) {
-    if (location_uuid) {
-      if (location_type == 'W'){
-        filters.push(`parent_Parent_Uuid: "${location_uuid}"`);
-        return true
-      }
-      else if (location_type == 'V'){
-        filters.push(`parent_Parent_Parent_Uuid: "${location_uuid}"`);
-        return true
-      }
-    }
-  });
+export function filter_location_by_parents(district_uuid, region_uuid, filters, location_type) {
+  let parentFilter = '';
+  if (district_uuid) {
+    if (location_type == 'W')
+      parentFilter = `parent_Uuid: "${district_uuid}"`
+    else if (location_type == 'V')
+      parentFilter = `parent_Parent_Uuid: "${district_uuid}"`
+  }
+  else if (region_uuid) {
+    if (location_type == 'W')
+      parentFilter = `parent_Parent_Uuid: "${region_uuid}"`
+    else if (location_type == 'V')
+      parentFilter = `parent_Parent_Parent_Uuid: "${region_uuid}"`
+  }
+  filters.push(parentFilter);
+  return true
 }
 
 export function fetchUserDistricts() {
@@ -178,8 +181,8 @@ export function fetchLocationsStr(
   if (Boolean(parent)) {
     filters.push(`parent_Uuid: "${parent.uuid}"`);
   }
-  else{
-    filter_location_by_parents([districts, regions], filters, types[level])
+  else {
+    filter_location_by_parents(districts, regions, filters, types[level])
   }
   let projections = ["id", "uuid", "type", "code", "name", nestParentsProjections(level)];
   return graphqlWithVariables(

--- a/src/actions.js
+++ b/src/actions.js
@@ -300,6 +300,18 @@ export function selectLocation(location, level, maxLevels) {
   };
 }
 
+export function selectDistrictLocation(location) {
+  return (dispatch) => {
+    dispatch({ type: `LOCATION_FILTER_DISTRICT_SELECTED`, payload: { location } });
+  };
+}
+
+export function selectRegionLocation(location) {
+  return (dispatch) => {
+    dispatch({ type: `LOCATION_FILTER_REGION_SELECTED`, payload: { location } });
+  };
+}
+
 export function fetchAllRegions() {
   let filters = [`type: "R"`];
 

--- a/src/pickers/DistrictPicker.js
+++ b/src/pickers/DistrictPicker.js
@@ -26,7 +26,8 @@ class DistrictPicker extends Component {
   };
 
   componentDidUpdate(nextProps) {
-    this.props.selectDistrictLocation(nextProps.value);
+    if (this.props.value !== nextProps.value)
+      this.props.selectDistrictLocation(nextProps.value);
   }
 
   render() {

--- a/src/pickers/DistrictPicker.js
+++ b/src/pickers/DistrictPicker.js
@@ -5,7 +5,9 @@ import { injectIntl } from "react-intl";
 import { TextField } from "@material-ui/core";
 import { withModulesManager, formatMessage, AutoSuggestion } from "@openimis/fe-core";
 import _debounce from "lodash/debounce";
+import { selectDistrictLocation } from "../actions.js";
 import { locationLabel } from "../utils";
+import { bindActionCreators } from "redux";
 
 const styles = (theme) => ({
   textField: {
@@ -22,6 +24,10 @@ class DistrictPicker extends Component {
   onSuggestionSelected = (v) => {
     this.props.onChange(v, locationLabel(v));
   };
+
+  componentDidUpdate(nextProps) {
+    this.props.selectDistrictLocation(nextProps.value);
+  }
 
   render() {
     const {
@@ -90,4 +96,14 @@ const mapStateToProps = (state) => ({
   userHealthFacilityFullPath: state.loc.userHealthFacilityFullPath,
 });
 
-export default withModulesManager(connect(mapStateToProps)(injectIntl(withTheme(withStyles(styles)(DistrictPicker)))));
+const mapDispatchToProps = (dispatch) =>
+  bindActionCreators(
+    {
+      selectDistrictLocation,
+    },
+    dispatch,
+  );
+
+export default withModulesManager(
+  connect(mapStateToProps, mapDispatchToProps)(injectIntl(withTheme(withStyles(styles)(DistrictPicker))))
+);

--- a/src/pickers/DistrictPicker.js
+++ b/src/pickers/DistrictPicker.js
@@ -22,12 +22,13 @@ class DistrictPicker extends Component {
   }
 
   onSuggestionSelected = (v) => {
+    if (this.props.value !== v)
+      this.props.selectDistrictLocation(v);
     this.props.onChange(v, locationLabel(v));
   };
 
-  componentDidUpdate(nextProps) {
-    if (this.props.value !== nextProps.value)
-      this.props.selectDistrictLocation(nextProps.value);
+  componentWillUnmount() {
+    this.props.clearLocations(1);
   }
 
   render() {

--- a/src/pickers/LocationPicker.js
+++ b/src/pickers/LocationPicker.js
@@ -45,6 +45,9 @@ const LocationPicker = (props) => {
 
   const restricted = useSelector((state) => state.loc[`userL${locationLevel}s`]);
 
+  const regions = useSelector((state) => state.loc[`l0s`]);
+  const districts = useSelector((state) => state.loc[`l1s`]);
+
   const dispatch = useDispatch();
   const handleChange = (__, value) => {
     onChange(value, locationLabel(value));
@@ -66,7 +69,14 @@ const LocationPicker = (props) => {
       if (parentLocations) {
         dispatch(fetchParentLocationsStr(modulesManager, locationLevel, parentLocations, searchString, 20));
       } else {
-        dispatch(fetchLocationsStr(modulesManager, locationLevel, parentLocation, searchString));
+        dispatch(fetchLocationsStr(
+          modulesManager,
+          locationLevel,
+          regions[0]?.uuid,
+          districts[0]?.uuid,
+          parentLocation,
+          searchString,
+          ));
       }
     }
   }, [searchString, parentLocation, parentLocations]);
@@ -76,7 +86,9 @@ const LocationPicker = (props) => {
       if (parentLocations) {
         dispatch(fetchParentLocationsStr(modulesManager, locationLevel, parentLocations, searchString, 20));
       } else {
-        dispatch(fetchLocationsStr(modulesManager, locationLevel, parentLocation, searchString));
+        dispatch(fetchLocationsStr(modulesManager, locationLevel,regions[0]?.uuid,
+          districts[0]?.uuid, parentLocation, searchString,
+          ));
       }
     } else {
       setSearchString("");

--- a/src/pickers/LocationPicker.js
+++ b/src/pickers/LocationPicker.js
@@ -72,11 +72,11 @@ const LocationPicker = (props) => {
         dispatch(fetchLocationsStr(
           modulesManager,
           locationLevel,
-          regions[0]?.uuid,
-          districts[0]?.uuid,
+          regions?.[0]?.uuid,
+          districts?.[0]?.uuid,
           parentLocation,
           searchString,
-          ));
+        ));
       }
     }
   }, [searchString, parentLocation, parentLocations]);
@@ -86,9 +86,10 @@ const LocationPicker = (props) => {
       if (parentLocations) {
         dispatch(fetchParentLocationsStr(modulesManager, locationLevel, parentLocations, searchString, 20));
       } else {
-        dispatch(fetchLocationsStr(modulesManager, locationLevel,regions[0]?.uuid,
-          districts[0]?.uuid, parentLocation, searchString,
-          ));
+        dispatch(fetchLocationsStr(
+          modulesManager, locationLevel, regions?.[0]?.uuid,
+          districts?.[0]?.uuid, parentLocation, searchString,
+        ));
       }
     } else {
       setSearchString("");

--- a/src/pickers/RegionPicker.js
+++ b/src/pickers/RegionPicker.js
@@ -30,17 +30,6 @@ class RegionPicker extends Component {
   componentDidUpdate(nextProps) {
     this.props.selectRegionLocation(nextProps.value);
   }
-  // TO DO:
-  // na componentDidMount/useEffect ... [], przy pierwszym renderze czytać value z propsów do state
-  // SPRAWDZIĆ CZY PROPSY SIĘ ZMIENIŁY, CHYBA TRZEBA DO TEGO DODAĆ MAPS STATE DO PROPS DLA 'l0s'
-  // (PO TO ŻEBY SIĘ TO NIE ODPALAŁO JAK KOMPONENT SIĘ RERENDERUJE)
-  // ZROBIĆ TO SAMO DLA DISTRICT PICKERA: akcja + reducer + component did update w district pickerze
-  // przekazywać w LocationPicker.js l0s i l1s na backend
-  // na backendzie sprawdzać jak: type = V to sprawdz parent, jak nie ma to parent_parent, jak nie ma to parent_parent_parent
-  // analogicznie dla M ale tylko parent i parent_parent
-  // to może coś zjebać, bo czasem l3s to nie jeden a kilka Villages, więc może trzeba zrobić osobny state dla selected lokacji
-  
-  // permsy w claimach, jest Claim i on bierze dane np. od policy, to czy policy ma sprawdzac też claim perms?
 
   componentDidMount() {
     if (allRegionsFlag) this.props.fetchAllRegions();
@@ -68,6 +57,7 @@ class RegionPicker extends Component {
     } = this.props;
 
     allRegionsFlag = allRegions;
+    console.log("im here, value:", value);
     if (!!userHealthFacilityFullPath) {
       return (
         <TextField

--- a/src/pickers/RegionPicker.js
+++ b/src/pickers/RegionPicker.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, useEffect } from "react";
 import { connect } from "react-redux";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { injectIntl } from "react-intl";
@@ -6,7 +6,7 @@ import { TextField } from "@material-ui/core";
 import { formatMessage, AutoSuggestion, withModulesManager } from "@openimis/fe-core";
 import _debounce from "lodash/debounce";
 import { locationLabel } from "../utils";
-import { fetchAllRegions } from "../actions.js";
+import { fetchAllRegions, selectRegionLocation } from "../actions.js";
 import { bindActionCreators } from "redux";
 
 const styles = (theme) => ({
@@ -23,7 +23,13 @@ class RegionPicker extends Component {
     this.selectThreshold = props.modulesManager.getConf("fe-location", "RegionPicker.selectThreshold", 10);
   }
 
-  onSuggestionSelected = (v) => this.props.onChange(v, locationLabel(v));
+  onSuggestionSelected = (v) => {
+    this.props.onChange(v, locationLabel(v));
+  }
+  
+  componentDidUpdate(nextProps) {
+    this.props.selectRegionLocation(nextProps.value);
+  }
 
   componentDidMount() {
     if (allRegionsFlag) this.props.fetchAllRegions();
@@ -51,7 +57,7 @@ class RegionPicker extends Component {
     } = this.props;
 
     allRegionsFlag = allRegions;
-
+    console.log("im here, value:", value);
     if (!!userHealthFacilityFullPath) {
       return (
         <TextField
@@ -101,6 +107,7 @@ const mapDispatchToProps = (dispatch) =>
   bindActionCreators(
     {
       fetchAllRegions,
+      selectRegionLocation,
     },
     dispatch,
   );

--- a/src/pickers/RegionPicker.js
+++ b/src/pickers/RegionPicker.js
@@ -30,6 +30,17 @@ class RegionPicker extends Component {
   componentDidUpdate(nextProps) {
     this.props.selectRegionLocation(nextProps.value);
   }
+  // TO DO:
+  // na componentDidMount/useEffect ... [], przy pierwszym renderze czytać value z propsów do state
+  // SPRAWDZIĆ CZY PROPSY SIĘ ZMIENIŁY, CHYBA TRZEBA DO TEGO DODAĆ MAPS STATE DO PROPS DLA 'l0s'
+  // (PO TO ŻEBY SIĘ TO NIE ODPALAŁO JAK KOMPONENT SIĘ RERENDERUJE)
+  // ZROBIĆ TO SAMO DLA DISTRICT PICKERA: akcja + reducer + component did update w district pickerze
+  // przekazywać w LocationPicker.js l0s i l1s na backend
+  // na backendzie sprawdzać jak: type = V to sprawdz parent, jak nie ma to parent_parent, jak nie ma to parent_parent_parent
+  // analogicznie dla M ale tylko parent i parent_parent
+  // to może coś zjebać, bo czasem l3s to nie jeden a kilka Villages, więc może trzeba zrobić osobny state dla selected lokacji
+  
+  // permsy w claimach, jest Claim i on bierze dane np. od policy, to czy policy ma sprawdzac też claim perms?
 
   componentDidMount() {
     if (allRegionsFlag) this.props.fetchAllRegions();
@@ -57,7 +68,6 @@ class RegionPicker extends Component {
     } = this.props;
 
     allRegionsFlag = allRegions;
-    console.log("im here, value:", value);
     if (!!userHealthFacilityFullPath) {
       return (
         <TextField

--- a/src/pickers/RegionPicker.js
+++ b/src/pickers/RegionPicker.js
@@ -57,7 +57,6 @@ class RegionPicker extends Component {
     } = this.props;
 
     allRegionsFlag = allRegions;
-    console.log("im here, value:", value);
     if (!!userHealthFacilityFullPath) {
       return (
         <TextField

--- a/src/pickers/RegionPicker.js
+++ b/src/pickers/RegionPicker.js
@@ -6,7 +6,7 @@ import { TextField } from "@material-ui/core";
 import { formatMessage, AutoSuggestion, withModulesManager } from "@openimis/fe-core";
 import _debounce from "lodash/debounce";
 import { locationLabel } from "../utils";
-import { fetchAllRegions, selectRegionLocation } from "../actions.js";
+import { fetchAllRegions, selectRegionLocation, clearLocations } from "../actions.js";
 import { bindActionCreators } from "redux";
 
 const styles = (theme) => ({
@@ -24,16 +24,17 @@ class RegionPicker extends Component {
   }
 
   onSuggestionSelected = (v) => {
+    if (this.props.value !== v)
+      this.props.selectRegionLocation(v);
     this.props.onChange(v, locationLabel(v));
-  }
-
-  componentDidUpdate(nextProps) {
-    if (this.props.value !== nextProps.value)
-      this.props.selectRegionLocation(nextProps.value);
   }
 
   componentDidMount() {
     if (allRegionsFlag) this.props.fetchAllRegions();
+  }
+
+  componentWillUnmount() {
+    this.props.clearLocations(0);
   }
 
   render() {
@@ -108,6 +109,7 @@ const mapDispatchToProps = (dispatch) =>
     {
       fetchAllRegions,
       selectRegionLocation,
+      clearLocations,
     },
     dispatch,
   );

--- a/src/pickers/RegionPicker.js
+++ b/src/pickers/RegionPicker.js
@@ -26,9 +26,10 @@ class RegionPicker extends Component {
   onSuggestionSelected = (v) => {
     this.props.onChange(v, locationLabel(v));
   }
-  
+
   componentDidUpdate(nextProps) {
-    this.props.selectRegionLocation(nextProps.value);
+    if (this.props.value !== nextProps.value)
+      this.props.selectRegionLocation(nextProps.value);
   }
 
   componentDidMount() {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -288,19 +288,16 @@ function reducer(
       };
     case "LOCATION_FILTER_SELECTED":
       let newState = { ...state };
-      console.log(action.payload);
       for (var i = action.payload.level + 1; i < action.payload.maxLevels; i++) {
         newState[`l${i}s`] = [];
       }
       return newState;
     case "LOCATION_FILTER_REGION_SELECTED":
-      console.log(action.payload);
       return {
         ...state,
         l0s: [action.payload.location],
       };
     case "LOCATION_FILTER_DISTRICT_SELECTED":
-      console.log(action.payload);
       return {
         ...state,
         l1s: [action.payload.location],

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -288,10 +288,23 @@ function reducer(
       };
     case "LOCATION_FILTER_SELECTED":
       let newState = { ...state };
+      console.log(action.payload);
       for (var i = action.payload.level + 1; i < action.payload.maxLevels; i++) {
         newState[`l${i}s`] = [];
       }
       return newState;
+    case "LOCATION_FILTER_REGION_SELECTED":
+      console.log(action.payload);
+      return {
+        ...state,
+        l0s: [action.payload.location],
+      };
+    case "LOCATION_FILTER_DISTRICT_SELECTED":
+      console.log(action.payload);
+      return {
+        ...state,
+        l1s: [action.payload.location],
+      };
     case "LOCATION_REGIONS_REQ":
       return {
         ...state,


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OTC-1027

Changes:
- selected region and district are now present in the store. 'l0s' and 'l1s' are saved in the store when user select them.
- villages are filtered by districts and regions too
- municipalities are filtered by regions too
- actions and reducers for above are added