### PR TITLE
OP-1420: Prevent invoking selectDistrictLocation if value is undefined

### DIFF
--- a/src/pickers/DistrictPicker.js
+++ b/src/pickers/DistrictPicker.js
@@ -22,8 +22,7 @@ class DistrictPicker extends Component {
   }
 
   onSuggestionSelected = (v) => {
-    if (this.props.value !== v)
-      this.props.selectDistrictLocation(v);
+    if (v && this.props.value !== v) this.props.selectDistrictLocation(v);
     this.props.onChange(v, locationLabel(v));
   };
 
@@ -108,5 +107,5 @@ const mapDispatchToProps = (dispatch) =>
   );
 
 export default withModulesManager(
-  connect(mapStateToProps, mapDispatchToProps)(injectIntl(withTheme(withStyles(styles)(DistrictPicker))))
+  connect(mapStateToProps, mapDispatchToProps)(injectIntl(withTheme(withStyles(styles)(DistrictPicker)))),
 );


### PR DESCRIPTION
[OP-1420](https://openimis.atlassian.net/browse/OP-1420)

Changes:
- If district is undefined, do not try to save it into Redux store.


[OP-1420]: https://openimis.atlassian.net/browse/OP-1420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ