### PR TITLE
OP-1419: Authorization error fixes, prevent form crash when clearing r…

### DIFF
--- a/src/components/HealthFacilityMasterPanel.js
+++ b/src/components/HealthFacilityMasterPanel.js
@@ -86,6 +86,7 @@ class HealthFacilityMasterPanel extends FormPanel {
                 value={edited.location}
                 readOnly={readOnly}
                 region={this.state.parentLocation}
+                withNull={true}
                 required={true}
                 onChange={(v, s) => this.updateDistrict(v)}
               />

--- a/src/components/TypeLocationsPaper.js
+++ b/src/components/TypeLocationsPaper.js
@@ -145,7 +145,7 @@ class ResultPane extends Component {
     return (
       <Fragment>
         <ProgressOrError progress={fetching} error={error} />
-        {!!fetched && !!locations && (
+        {!!fetched && !!locations && !error && (
           <List component="nav">
             {locations.map((l, idx) => (
               <ListItem

--- a/src/pickers/RegionPicker.js
+++ b/src/pickers/RegionPicker.js
@@ -24,10 +24,9 @@ class RegionPicker extends Component {
   }
 
   onSuggestionSelected = (v) => {
-    if (this.props.value !== v)
-      this.props.selectRegionLocation(v);
+    if (v && this.props.value !== v) this.props.selectRegionLocation(v);
     this.props.onChange(v, locationLabel(v));
-  }
+  };
 
   componentDidMount() {
     if (allRegionsFlag) this.props.fetchAllRegions();


### PR DESCRIPTION
…egion

[OP-1419](https://openimis.atlassian.net/browse/OP-1419)

Changes:

- If authorization error occurs, do not show locations user is not permitted to see. Just display auth error instead.
- Prevent form crash when clearing a Region.
- Display "Any" as a DistrictPicker placeholder when district is not specified.

[OP-1419]: https://openimis.atlassian.net/browse/OP-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ