### PR TITLE
OP-1438: disable save button on historical hf

### DIFF
--- a/src/components/HealthFacilityForm.js
+++ b/src/components/HealthFacilityForm.js
@@ -158,7 +158,7 @@ class HealthFacilityForm extends Component {
               onEditedChanged={this.onEditedChanged}
               actions={actions}
               contributedPanelsKey={HF_FORM_CONTRIBUTION_KEY}
-              openDirty={save}
+              openDirty={save && !readOnly}
             />
           </Fragment>
         )}

--- a/src/components/TypeLocationsPaper.js
+++ b/src/components/TypeLocationsPaper.js
@@ -152,8 +152,8 @@ class ResultPane extends Component {
                 key={`location-${type}-${idx}`}
                 button
                 selected={location && location.id === l.id}
-                onClick={(e) => !!l.uuid && !!onSelect && onSelect(l)}
-                onDoubleClick={(e) => !!l.uuid && rights.includes(RIGHT_LOCATION_EDIT) && onEdit(l)}
+                onClick={(e) => !!l.uuid && !!onSelect && !readOnly && onSelect(l)}
+                onDoubleClick={(e) => !!l.uuid && !readOnly && rights.includes(RIGHT_LOCATION_EDIT) && onEdit(l)}
                 className={!l.uuid || !!l.clientMutationId ? classes.lockedRow : null}
               >
                 <ListItemText>


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OP-1446

This PR disables save button on historical data and also doesn't allow to change hf's locations.