### PR TITLE
ONI-105: Contract start/end date fields added.

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -314,6 +314,8 @@ function formatHealthFacilityGQL(hf) {
     ${!!hf.servicesPricelist ? `servicesPricelistId: ${decodeId(hf.servicesPricelist.id)}` : ""}
     ${!!hf.itemsPricelist ? `itemsPricelistId: ${decodeId(hf.itemsPricelist.id)}` : ""}
     ${!!hf.mutationExtensions ? `mutationExtensions: ${formatJsonField(hf.mutationExtensions)}` : ""}
+    ${!!hf.contractStartDate ? `contractStartDate: ${hf.contractStartDate}` : ""}
+    ${!!hf.contractEndDate ? `contractEndDate: ${hf.contractEndDate}` : ""}
     ${formatCatchments(hf.catchments)}
   `;
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -110,6 +110,8 @@ export function fetchHealthFacility(mm, healthFacilityUuid, healthFacilityCode) 
     "servicesPricelist{id, uuid, name}",
     "itemsPricelist{id, uuid, name}",
     "catchments{id, location{id, uuid, code, name}, catchment}",
+    "contractStartDate",
+    "contractEndDate",
     "validityFrom",
     "validityTo",
   ];
@@ -314,8 +316,8 @@ function formatHealthFacilityGQL(hf) {
     ${!!hf.servicesPricelist ? `servicesPricelistId: ${decodeId(hf.servicesPricelist.id)}` : ""}
     ${!!hf.itemsPricelist ? `itemsPricelistId: ${decodeId(hf.itemsPricelist.id)}` : ""}
     ${!!hf.mutationExtensions ? `mutationExtensions: ${formatJsonField(hf.mutationExtensions)}` : ""}
-    ${!!hf.contractStartDate ? `contractStartDate: ${hf.contractStartDate}` : ""}
-    ${!!hf.contractEndDate ? `contractEndDate: ${hf.contractEndDate}` : ""}
+    ${!!hf.contractStartDate ? `contractStartDate: "${hf.contractStartDate}"` : ""}
+    ${!!hf.contractEndDate ? `contractEndDate: "${hf.contractEndDate}"` : ""}
     ${formatCatchments(hf.catchments)}
   `;
 }

--- a/src/components/HealthFacilityMasterPanel.js
+++ b/src/components/HealthFacilityMasterPanel.js
@@ -266,7 +266,6 @@ class HealthFacilityMasterPanel extends FormPanel {
                 onChange={(date) => this.updateAttribute("contractStartDate", date)}
                 readOnly={readOnly}
                 required={false}
-                // maxDate={edited.dateTo < edited.dateClaimed ? edited.dateTo : edited.dateClaimed}
               />
             </Grid>
           }
@@ -285,7 +284,6 @@ class HealthFacilityMasterPanel extends FormPanel {
                 onChange={(date) => this.updateAttribute("contractEndDate", date)}
                 readOnly={readOnly}
                 required={false}
-                // maxDate={edited.dateTo < edited.dateClaimed ? edited.dateTo : edited.dateClaimed}
               />
             </Grid>
           }

--- a/src/components/HealthFacilityMasterPanel.js
+++ b/src/components/HealthFacilityMasterPanel.js
@@ -254,6 +254,44 @@ class HealthFacilityMasterPanel extends FormPanel {
         />
         <ControlledField
           module="location"
+          id="HealthFacility.contractStartDate"
+          field={
+            <Grid item xs={2} className={classes.item}>
+              <PublishedComponent
+                pubRef="core.DatePicker"
+                value={edited.contractStartDate}
+                module="claim"
+                label="HealthFacilityForm.contractStartDate"
+                reset={reset}
+                onChange={(date) => this.updateAttribute("contractStartDate", date)}
+                readOnly={readOnly}
+                required={false}
+                // maxDate={edited.dateTo < edited.dateClaimed ? edited.dateTo : edited.dateClaimed}
+              />
+            </Grid>
+          }
+        />
+        <ControlledField
+          module="location"
+          id="HealthFacility.contractEndDate"
+          field={
+            <Grid item xs={2} className={classes.item}>
+              <PublishedComponent
+                pubRef="core.DatePicker"
+                value={edited.contractEndDate}
+                module="claim"
+                label="HealthFacilityForm.contractEndDate"
+                reset={reset}
+                onChange={(date) => this.updateAttribute("contractEndDate", date)}
+                readOnly={readOnly}
+                required={false}
+                // maxDate={edited.dateTo < edited.dateClaimed ? edited.dateTo : edited.dateClaimed}
+              />
+            </Grid>
+          }
+        />
+        <ControlledField
+          module="location"
           id="HealthFacility.fax"
           field={
             <Grid item xs={1} className={classes.item}>

--- a/src/components/HealthFacilityMasterPanel.js
+++ b/src/components/HealthFacilityMasterPanel.js
@@ -260,7 +260,7 @@ class HealthFacilityMasterPanel extends FormPanel {
               <PublishedComponent
                 pubRef="core.DatePicker"
                 value={edited.contractStartDate}
-                module="claim"
+                module="location"
                 label="HealthFacilityForm.contractStartDate"
                 reset={reset}
                 onChange={(date) => this.updateAttribute("contractStartDate", date)}
@@ -278,7 +278,7 @@ class HealthFacilityMasterPanel extends FormPanel {
               <PublishedComponent
                 pubRef="core.DatePicker"
                 value={edited.contractEndDate}
-                module="claim"
+                module="location"
                 label="HealthFacilityForm.contractEndDate"
                 reset={reset}
                 onChange={(date) => this.updateAttribute("contractEndDate", date)}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -115,6 +115,8 @@
   "location.HealthFacilityForm.fax": "Fax",
   "location.HealthFacilityForm.email": "Email",
   "location.HealthFacilityForm.codeTaken": "Code already taken.",
+  "HealthFacilityForm.contractStartDate": "Contract Start Date",
+  "HealthFacilityForm.contractEndDate": "Contract End Date",
   "location.HealthFacilityFilter.showHistory": "Show historical values",
   "location.CreateHealthFacility.mutationLabel": "Create Health Facility {code}",
   "location.UpdateHealthFacility.mutationLabel": "Update Health Facilityt { code}",


### PR DESCRIPTION
Ticket: https://openimis.atlassian.net/browse/ONI-105

Required backend: https://github.com/openimis/openimis-be-location_py/pull/84

Changes:
- Added contract start/end date field to HF.