### PR TITLE
OP-1725: remove empty/null option from dropdowns

### DIFF
--- a/src/components/CoarseLocation.js
+++ b/src/components/CoarseLocation.js
@@ -74,7 +74,7 @@ class CoarseLocation extends Component {
                 readOnly={readOnly}
                 required={required}
                 value={region}
-                withNull={true}
+                withNull={false}
                 filterLabels={filterLabels}
                 onChange={this.onChangeRegion}
                 allRegions={allRegions}
@@ -93,7 +93,7 @@ class CoarseLocation extends Component {
                 required={required}
                 value={district}
                 region={this.state.region}
-                withNull={true}
+                withNull={false}
                 filterLabels={filterLabels}
                 onChange={this.onChangeDistrict}
               />

--- a/src/components/DetailedHealthFacility.js
+++ b/src/components/DetailedHealthFacility.js
@@ -40,7 +40,7 @@ const DetailedHealthFacility = (props) => {
               pubRef="location.HealthFacilityLevelPicker"
               value={level}
               readOnly={readOnly}
-              withNull
+              withNull={false}
               onChange={setLevel}
             />
           </Box>

--- a/src/components/HealthFacilityMasterPanel.js
+++ b/src/components/HealthFacilityMasterPanel.js
@@ -71,7 +71,7 @@ class HealthFacilityMasterPanel extends FormPanel {
               <PublishedComponent
                 pubRef="location.RegionPicker"
                 value={edited.parentLocation}
-                withNull={true}
+                withNull={false}
                 readOnly={readOnly}
                 onChange={(v, s) => this.updateRegion(v)}
               />
@@ -88,7 +88,7 @@ class HealthFacilityMasterPanel extends FormPanel {
                 value={edited.location}
                 readOnly={readOnly}
                 region={edited.parentLocation}
-                withNull={true}
+                withNull={false}
                 required={true}
                 onChange={(v, s) => this.updateDistrict(v)}
               />
@@ -103,9 +103,9 @@ class HealthFacilityMasterPanel extends FormPanel {
               <PublishedComponent
                 pubRef="location.HealthFacilityLegalFormPicker"
                 value={!!edited.legalForm ? edited.legalForm.code : null}
-                nullLabel="empty"
                 reset={reset}
                 readOnly={readOnly}
+                withNull={false}
                 required={true}
                 onChange={(v, s) => this.updateAttribute("legalForm", !!v ? { code: v } : null)}
               />
@@ -120,9 +120,9 @@ class HealthFacilityMasterPanel extends FormPanel {
               <PublishedComponent
                 pubRef="location.HealthFacilityLevelPicker"
                 value={edited.level}
-                nullLabel="empty"
                 reset={reset}
                 readOnly={readOnly}
+                withNull={false}
                 required={true}
                 onChange={(v, s) => this.updateAttribute("level", v)}
               />
@@ -137,8 +137,8 @@ class HealthFacilityMasterPanel extends FormPanel {
               <PublishedComponent
                 pubRef="location.HealthFacilitySubLevelPicker"
                 value={!!edited.subLevel ? edited.subLevel.code : null}
-                nullLabel="empty"
                 reset={reset}
+                withNull={false}
                 readOnly={readOnly}
                 onChange={(v, s) => this.updateAttribute("subLevel", !!v ? { code: v } : null)}
               />
@@ -153,9 +153,9 @@ class HealthFacilityMasterPanel extends FormPanel {
               <PublishedComponent
                 pubRef="medical.CareTypePicker"
                 value={edited.careType}
-                nullLabel="location.HealthFacilityMasterPanel.careType.nullLabel"
                 reset={reset}
                 readOnly={readOnly}
+                withNull={false}
                 required={true}
                 onChange={(v, s) => this.updateAttribute("careType", v)}
               />


### PR DESCRIPTION
[OP-1725](https://openimis.atlassian.net/browse/OP-1725)

Changes:

- Remove the 'none/null' option from the dropdowns menu in the form.

[OP-1725]: https://openimis.atlassian.net/browse/OP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ