### PR TITLE
OP-1817: hide validity dates if historical data not requested

### DIFF
--- a/src/components/HealthFacilitiesSearcher.js
+++ b/src/components/HealthFacilitiesSearcher.js
@@ -44,8 +44,8 @@ class HealthFacilitiesSearcher extends Component {
       "healthFacilitySummaries.email",
       "healthFacilitySummaries.region",
       "healthFacilitySummaries.district",
-      "healthFacilitySummaries.validityFrom",
-      "healthFacilitySummaries.validityTo",
+      filters?.showHistory?.value ? "healthFacilitySummaries.validityFrom" : null,
+      filters?.showHistory?.value ? "healthFacilitySummaries.validityTo" : null,
     ];
     if (this.props.rights.includes(RIGHT_HEALTH_FACILITY_DELETE)) {
       headers.push(null);
@@ -64,8 +64,8 @@ class HealthFacilitiesSearcher extends Component {
     null,
     null,
     null,
-    ["validityFrom", false],
-    ["validityTo", false],
+    filters?.showHistory?.value ? ["validityFrom", false] : null,
+    filters?.showHistory?.value ? ["validityTo", false] : null,
   ];
 
   itemFormatters = (filters) => {
@@ -91,9 +91,14 @@ class HealthFacilitiesSearcher extends Component {
       (hf) => hf.email,
       (hf) => (hf.location && hf.location.parent ? `${hf.location.parent.code} - ${hf.location.parent.name}` : null),
       (hf) => (hf.location ? `${hf.location.code} - ${hf.location.name}` : null),
-
-      (hf) => formatDateFromISO(this.props.modulesManager, this.props.intl, hf.validityFrom),
-      (hf) => formatDateFromISO(this.props.modulesManager, this.props.intl, hf.validityTo),
+      (hf) =>
+        filters?.showHistory?.value
+          ? formatDateFromISO(this.props.modulesManager, this.props.intl, hf.validityFrom)
+          : null,
+      (hf) =>
+        filters?.showHistory?.value
+          ? formatDateFromISO(this.props.modulesManager, this.props.intl, hf.validityTo)
+          : null,
     ];
     if (this.props.rights.includes(RIGHT_HEALTH_FACILITY_DELETE)) {
       formatters.push((hf) =>

--- a/src/components/HealthFacilitiesSearcher.js
+++ b/src/components/HealthFacilitiesSearcher.js
@@ -6,7 +6,9 @@ import _ from "lodash";
 import DeleteIcon from "@material-ui/icons/Delete";
 import {
   withModulesManager,
-  IconButton,
+  formatMessage,
+  formatMessageWithValues,
+  PublishedComponent,
   formatDateFromISO,
   journalize,
   coreConfirm,
@@ -14,7 +16,7 @@ import {
 } from "@openimis/fe-core";
 import HealthFacilityFilter from "./HealthFacilityFilter";
 import { fetchHealthFacilitySummaries, deleteHealthFacility } from "../actions";
-import { formatMessage, formatMessageWithValues, PublishedComponent } from "@openimis/fe-core";
+import { IconButton } from "@material-ui/core";
 import { RIGHT_HEALTH_FACILITY_DELETE } from "../constants";
 
 class HealthFacilitiesSearcher extends Component {

--- a/src/components/HealthFacilitiesSearcher.js
+++ b/src/components/HealthFacilitiesSearcher.js
@@ -4,11 +4,17 @@ import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
 import _ from "lodash";
 import DeleteIcon from "@material-ui/icons/Delete";
-import { withModulesManager, decodeId, formatDateFromISO, journalize, coreConfirm, Searcher } from "@openimis/fe-core";
+import {
+  withModulesManager,
+  IconButton,
+  formatDateFromISO,
+  journalize,
+  coreConfirm,
+  Searcher,
+} from "@openimis/fe-core";
 import HealthFacilityFilter from "./HealthFacilityFilter";
 import { fetchHealthFacilitySummaries, deleteHealthFacility } from "../actions";
 import { formatMessage, formatMessageWithValues, PublishedComponent } from "@openimis/fe-core";
-import { IconButton } from "@material-ui/core";
 import { RIGHT_HEALTH_FACILITY_DELETE } from "../constants";
 
 class HealthFacilitiesSearcher extends Component {


### PR DESCRIPTION
[OP-1817](https://openimis.atlassian.net/browse/OP-1817)

Changes:
- Health Facilities Searcher: Show or hide "Validity From" and "Validity To" columns based on the _showHistory_ filter.

[OP-1817]: https://openimis.atlassian.net/browse/OP-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ