### PR TITLE
set text beside icons OP-2578

### DIFF
--- a/src/components/HealthFacilitiesSearcher.js
+++ b/src/components/HealthFacilitiesSearcher.js
@@ -16,7 +16,7 @@ import {
 } from "@openimis/fe-core";
 import HealthFacilityFilter from "./HealthFacilityFilter";
 import { fetchHealthFacilitySummaries, deleteHealthFacility } from "../actions";
-import { IconButton } from "@material-ui/core";
+import { Button } from "@material-ui/core";
 import { RIGHT_HEALTH_FACILITY_DELETE } from "../constants";
 
 class HealthFacilitiesSearcher extends Component {
@@ -114,9 +114,12 @@ class HealthFacilitiesSearcher extends Component {
     if (this.props.rights.includes(RIGHT_HEALTH_FACILITY_DELETE)) {
       formatters.push((hf) =>
         hf.validityTo ? null : (
-          <IconButton disabled={!!hf.clientMutationId} onClick={(e) => this.onDelete(hf)}>
-            <DeleteIcon />
-          </IconButton>
+          <Button 
+            startIcon={<DeleteIcon />}
+            disabled={!!hf.clientMutationId}
+            onClick={(e) => this.onDelete(hf)}>
+            {formatMessage(this.props.intl, "location", "deleteHealthFacility.buttonText")}
+          </Button>
         ),
       );
     }

--- a/src/components/TypeLocationsPaper.js
+++ b/src/components/TypeLocationsPaper.js
@@ -7,6 +7,7 @@ import AddIcon from "@material-ui/icons/Add";
 import MoveIcon from "@material-ui/icons/Shuffle";
 import DeleteIcon from "@material-ui/icons/Delete";
 import ReplayIcon from "@material-ui/icons/Replay";
+import Tooltip from "@material-ui/core/Tooltip";
 import { formatMessage, formatMessageWithValues, SearcherPane, ProgressOrError } from "@openimis/fe-core";
 import EditLocationDialog from "./EditLocationDialog";
 import MoveLocationDialog from "./MoveLocationDialog";
@@ -162,14 +163,18 @@ class ResultPane extends Component {
                 {!!l.uuid && (
                   <ListItemSecondaryAction>
                     {!!onMove && rights.includes(RIGHT_LOCATION_MOVE) && (
-                      <IconButton onClick={(e) => onMove(l)}>
-                        <MoveIcon />
-                      </IconButton>
+                      <Tooltip title="Move">
+                        <IconButton onClick={(e) => onMove(l)}>
+                          <MoveIcon />
+                        </IconButton>
+                      </Tooltip>
                     )}
                     {!!onDelete && rights.includes(RIGHT_LOCATION_DELETE) && (
-                      <IconButton edge="end" onClick={(e) => onDelete(l, idx)}>
-                        <DeleteIcon />
-                      </IconButton>
+                      <Tooltip title="Delete">
+                        <IconButton edge="end" onClick={(e) => onDelete(l, idx)}>
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
                     )}
                     {!!InlineInput && (
                       <InlineInput location={l} onChange={onChange} inlineValue={inlineValue} readOnly={readOnly} />

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -146,5 +146,6 @@
   "location.gql_mutation_create_region_locations_perms": "Location | Mutation Create Region Locations",
   "location.gql_mutation_create_health_facilities_perms": "Location | Mutation Create Health Facilities",
   "location.gql_mutation_edit_health_facilities_perms": "Location | Mutation Edit Health Facilities",
-  "location.gql_mutation_delete_health_facilities_perms": "Location | Mutation Delete Health Facilities"
+  "location.gql_mutation_delete_health_facilities_perms": "Location | Mutation Delete Health Facilities",
+  "location.deleteHealthFacility.buttonText": "Delete"
 }


### PR DESCRIPTION
Added descriptive text next to icon-only buttons to improve usability and accessibility.
According to [WCAG 2.1](https://www.w3.org/TR/WCAG21/) and usability best practices, relying on icons alone can create confusion since many icons do not have a universal meaning. By adding short descriptive labels, the interface becomes more intuitive, accessible to all users, and compliant with accessibility standards.