### PR TITLE
feat: Make location cascader support multi-select

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -199,6 +199,28 @@ export function fetchLocationsStr(mm, level, regions = null, districts = null, p
   );
 }
 
+export function fetchLocationsByUuids(uuids, maxLevel = 4) {
+  if (!uuids || uuids.length === 0) {
+    return { type: "LOCATION_LOCATIONS_BY_UUIDS_EMPTY" };
+  }
+
+  const uuidFilters = uuids.map(uuid => `"${uuid}"`).join(',');
+  const projections = ["id", "uuid", "type", "code", "name", nestParentsProjections(maxLevel - 1)];
+
+  return graphqlWithVariables(
+    `
+      {
+        locationsStr(uuid_In: [${uuidFilters}])
+        {
+          ${_pageAndEdges(projections)}
+        }
+      }
+      `,
+    {},
+    `LOCATION_LOCATIONS_BY_UUIDS`,
+  );
+}
+
 export function fetchParentLocationsStr(
   modulesManager,
   level,

--- a/src/pickers/LocationCascader.js
+++ b/src/pickers/LocationCascader.js
@@ -4,15 +4,31 @@ import AutorenewIcon from '@material-ui/icons/Autorenew';
 import React, { useEffect, useState, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import Cascader from "rc-cascader";
-import { TextField } from "@material-ui/core";
+import { TextField, Chip } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { useModulesManager, useTranslations } from "@openimis/fe-core";
-import { fetchLocationsStr } from "../actions";
+import { fetchLocationsStr, fetchLocationsByUuids } from "../actions";
 import { locationLabel } from "../utils";
+import _ from "lodash";
 
 const styles = () => ({
   root: {
     width: "100%",
+  },
+  chipsContainer: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: "4px",
+    flex: 1,
+    minWidth: 0,
+    margin: "3px",
+  },
+  inputRoot: {
+    flexWrap: "wrap",
+    "& input": {
+      width: 0,
+      minWidth: 0,
+    },
   },
 });
 
@@ -39,6 +55,7 @@ const LocationCascader = ({
   readOnly,
   classes,
   value,
+  multiple = false,
 }) => {
   const modulesManager = useModulesManager();
   const { formatMessage } = useTranslations("location", modulesManager);
@@ -49,7 +66,7 @@ const LocationCascader = ({
   );
 
   const [options, setOptions] = useState([]);
-  const [inputValue, setInputValue] = useState("");
+  const [locations, setLocations] = useState(multiple ? [] : "");
   const [defaultValue, setDefaultValue] = useState([]);
 
   const locationCache = useRef({}); // { [parentUuid]: [childLocations] }
@@ -112,17 +129,53 @@ const LocationCascader = ({
     if (value?.uuid) {
       const { names, uuids } = extractPathFromValue(value);
       setDefaultValue(uuids);
-      setInputValue(locationLabel(value));
+      setLocations(locationLabel(value));
+    } else if (multiple && value?.length) {
+      if(!_.isEqual(_.sortBy(value.map(v => v.uuid)), _.sortBy((locations || []).map(v => v.uuid)))) {
+        const hasPartialLocations = value.some(loc => loc.uuid && !loc.name);
+        if (hasPartialLocations) {
+          const uuidsToFetch = value.filter(loc => loc.uuid && !loc.name).map(loc => loc.uuid);
+          if (uuidsToFetch.length > 0) {
+            dispatch(fetchLocationsByUuids(uuidsToFetch, maxLevel));
+          }
+        } else {
+          setDefaultValue(value.map(v => v.uuid));
+          setLocations(value)
+        }
+      }
     } else {
       setDefaultValue([]);
-      setInputValue("");
+      setLocations("");
     }
-  }, [value]);
+  }, [value, multiple]);
+
+  useEffect(() => {
+    if (locState.fetchedLocationsByUuids && locState.locationsByUuids?.length > 0) {
+      const fetchedLocationsMap = new Map(
+        locState.locationsByUuids.map(loc => [loc.uuid, loc])
+      );
+
+      if (multiple && Array.isArray(value) && value.length > 0) {
+        const enrichedLocations = value.map(loc => {
+          if (loc.uuid && !loc.name) {
+            return fetchedLocationsMap.get(loc.uuid) || loc;
+          }
+          return loc;
+        });
+
+        setDefaultValue(enrichedLocations.map(v => v.uuid));
+        setLocations(enrichedLocations);
+      }
+    }
+  }, [locState.fetchedLocationsByUuids, locState.locationsByUuids]);
 
   const handleCascaderChange = (uuids, selectedOptions) => {
-    const selected = selectedOptions[selectedOptions.length - 1];
-    setInputValue(selected?.label || "");
-    onChange?.(selected.raw, locationLabel(selected.raw));
+    // selectedOptions contains the selected location and all its parent levels for each selection
+    // unwrap to keep only the lowest level for each selection
+    const unnestedOptions = (multiple ? selectedOptions : [selectedOptions]).map(opts => opts[opts.length - 1])
+    const rawVals = unnestedOptions.map(selected => selected.raw)
+    setLocations(rawVals);
+    onChange?.(multiple ? rawVals : rawVals[0]);
   };
 
   return (
@@ -134,17 +187,32 @@ const LocationCascader = ({
         onChange={handleCascaderChange}
         changeOnSelect={true}
         disabled={readOnly}
+        checkable={multiple}
         expandIcon={<KeyboardArrowRightIcon fontSize="small" />}
         loadingIcon={<AutorenewIcon fontSize="small" className="spin" />}
       >
         <TextField
           label={label || formatMessage("LocationPicker.label")}
-          value={inputValue}
+          value={multiple ? "" : locations}
           fullWidth
           disabled={readOnly}
           InputProps={{
             readOnly: true,
-            endAdornment: (<ArrowDropDownIcon 
+            classes: multiple && Array.isArray(locations) && locations.length > 0 ? {
+              root: classes.inputRoot,
+            } : undefined,
+            startAdornment: multiple && Array.isArray(locations) && locations.length > 0 ? (
+              <div className={classes.chipsContainer}>
+                {locations.map((location) => (
+                  <Chip
+                    key={location.uuid}
+                    label={locationLabel(location)}
+                    disabled={readOnly}
+                  />
+                ))}
+              </div>
+            ) : null,
+            endAdornment: (<ArrowDropDownIcon
               style={{ color: "rgba(0, 0, 0, 0.54)" }}
             />),
           }}

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -57,6 +57,10 @@ function reducer(
     fetchingAllL1s: false,
     fetchedAllL1s: false,
     errorAllL1s: null,
+    locationsByUuids: [],
+    fetchingLocationsByUuids: false,
+    fetchedLocationsByUuids: false,
+    errorLocationsByUuids: null,
   },
   action,
 ) {
@@ -514,6 +518,37 @@ function reducer(
       return dispatchMutationResp(state, "updateHealthFacility", action);
     case "LOCATION_DELETE_HEALTH_FACILITY_RESP":
       return dispatchMutationResp(state, "deleteHealthFacility", action);
+    case "LOCATION_LOCATIONS_BY_UUIDS_REQ":
+      return {
+        ...state,
+        fetchingLocationsByUuids: true,
+        fetchedLocationsByUuids: false,
+        locationsByUuids: [],
+        errorLocationsByUuids: null,
+      };
+    case "LOCATION_LOCATIONS_BY_UUIDS_RESP":
+      const fetchedLocations = parseData(action.payload.data.locationsStr);
+      return {
+        ...state,
+        fetchingLocationsByUuids: false,
+        fetchedLocationsByUuids: true,
+        locationsByUuids: fetchedLocations,
+        errorLocationsByUuids: formatGraphQLError(action.payload),
+      };
+    case "LOCATION_LOCATIONS_BY_UUIDS_ERR":
+      return {
+        ...state,
+        fetchingLocationsByUuids: false,
+        errorLocationsByUuids: formatServerError(action.payload),
+      };
+    case "LOCATION_LOCATIONS_BY_UUIDS_EMPTY":
+      return {
+        ...state,
+        fetchingLocationsByUuids: false,
+        fetchedLocationsByUuids: true,
+        locationsByUuids: [],
+        errorLocationsByUuids: null,
+      };
     case "CORE_AUTH_LOGOUT":
       return {
         ...state,


### PR DESCRIPTION
# Description

This is used in supporting payroll creation filtering criteria. Prior to this change, LocationCascader only supports single select, which was sufficient in its usage for project creation. In case of payroll creation, we want to allow users to create a payroll where beneficiaries from one or more projects can be paid. Demo included below. Related PR will be linked.

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires https://github.com/openimis/openimis-be-payroll_py/pull/79, it needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

![location_cascader_multiselect](https://github.com/user-attachments/assets/b4b5f771-1cf3-4019-b526-c1483d914794)

## Checklist
- [ ] Unit tests added/modified
- [x] I18n / translation handled
