### PR TITLE
Fix: population should be formatted as int [OP-2988]

### DIFF
--- a/src/components/EditLocationDialog.js
+++ b/src/components/EditLocationDialog.js
@@ -144,6 +144,7 @@ class EditLocationDialog extends Component {
                       module="location"
                       label="EditDialog.male"
                       max={MAX_INT_NUMBER}
+                      numberOfDecimals={0}
                       value={!!this.state.data ? this.state.data.malePopulation : null}
                       onChange={(v) => this.changeData("malePopulation", v)}
                     />
@@ -153,6 +154,7 @@ class EditLocationDialog extends Component {
                       module="location"
                       label="EditDialog.female"
                       max={MAX_INT_NUMBER}
+                      numberOfDecimals={0}
                       value={!!this.state.data ? this.state.data.femalePopulation : null}
                       onChange={(v) => this.changeData("femalePopulation", v)}
                     />
@@ -162,6 +164,7 @@ class EditLocationDialog extends Component {
                       module="location"
                       label="EditDialog.other"
                       max={MAX_INT_NUMBER}
+                      numberOfDecimals={0}
                       value={!!this.state.data ? this.state.data.otherPopulation : null}
                       onChange={(v) => this.changeData("otherPopulation", v)}
                     />
@@ -171,6 +174,7 @@ class EditLocationDialog extends Component {
                       module="location"
                       label="EditDialog.family"
                       max={MAX_INT_NUMBER}
+                      numberOfDecimals={0}
                       value={!!this.state.data ? this.state.data.families : null}
                       onChange={(v) => this.changeData("families", v)}
                     />
@@ -227,6 +231,7 @@ class EditLocationDialog extends Component {
                       module="location"
                       label="EditDialog.male"
                       max={MAX_INT_NUMBER}
+                      numberOfDecimals={0}
                       value={!!this.state.data ? this.state.data.malePopulation : null}
                       onChange={(v) => this.changeData("malePopulation", v)}
                     />
@@ -236,6 +241,7 @@ class EditLocationDialog extends Component {
                       module="location"
                       label="EditDialog.female"
                       max={MAX_INT_NUMBER}
+                      numberOfDecimals={0}
                       value={!!this.state.data ? this.state.data.femalePopulation : null}
                       onChange={(v) => this.changeData("femalePopulation", v)}
                     />
@@ -245,6 +251,7 @@ class EditLocationDialog extends Component {
                       module="location"
                       label="EditDialog.other"
                       max={MAX_INT_NUMBER}
+                      numberOfDecimals={0}
                       value={!!this.state.data ? this.state.data.otherPopulation : null}
                       onChange={(v) => this.changeData("otherPopulation", v)}
                     />
@@ -254,6 +261,7 @@ class EditLocationDialog extends Component {
                       module="location"
                       label="EditDialog.family"
                       max={MAX_INT_NUMBER}
+                      numberOfDecimals={0}
                       value={!!this.state.data ? this.state.data.families : null}
                       onChange={(v) => this.changeData("families", v)}
                     />


### PR DESCRIPTION
# Description

Population fields should be formatted as int instead of decimals.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires: https://github.com/openimis/openimis-fe-core_js/pull/308
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [x] External reference (e.g., Jira): https://openimis.atlassian.net/browse/OP-2988

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
