### PR TITLE
fix space in district picker

### DIFF
--- a/src/pickers/DistrictPicker.jsx
+++ b/src/pickers/DistrictPicker.jsx
@@ -19,23 +19,15 @@ const StyledDistrictPicker = styled('div')(({ theme }) => ({
     fontSize: '1rem',
     fontWeight: 500,
   },
-  '& .MuiTextField-root': {
-    minHeight: '56px',
-    '& .MuiInputBase-root': {
-      minHeight: '56px',
-      fontSize: '1rem',
-      padding: theme.spacing(0.5, 1),
-    },
-    '& .MuiInputBase-input': {
-      padding: theme.spacing(1.5, 1),
-      fontSize: '1rem',
-    },
-  },
   '& .MuiAutocomplete-root': {
-    minWidth: '200px',
+    width: '100%',
     '& .MuiInputBase-root': {
-      minHeight: '56px',
+      minHeight: '40px',        // hauteur normale, pas 56px
       padding: theme.spacing(0.5, 1),
+      fontSize: '1rem',
+    },
+    '& .MuiAutocomplete-input': {
+      padding: theme.spacing(0.5, 1), // pas 1.5 en plus
     },
   },
 }));


### PR DESCRIPTION
# Description

There is unnecessary spacing in the filter panel around the District field

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1430" height="736" alt="Screenshot 2026-07-06 at 6 11 18 PM" src="https://github.com/user-attachments/assets/53acd4cc-bda7-4558-a623-30e49c95b655" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
