### PR TITLE
Improve the Health Facility Level Field in the First Service Point Panel

### DIFF
--- a/src/components/DetailedHealthFacility.jsx
+++ b/src/components/DetailedHealthFacility.jsx
@@ -36,7 +36,7 @@ const DetailedHealthFacility = (props) => {
           module="location"
           id="DetailedHealthFacility.Level"
           field={
-            <Box flexGrow={1} className="item">
+            <Box flexGrow={1} minWidth="200px" className="item">
               <PublishedComponent
                 pubRef="location.HealthFacilityLevelPicker"
                 value={level}
@@ -51,7 +51,7 @@ const DetailedHealthFacility = (props) => {
           module="location"
           id="DetailedHealthFacility.HF"
           field={
-            <Box flexGrow={2} className="item">
+            <Box flexGrow={2} minWidth="400px" className="item">
               <PublishedComponent
                 pubRef="location.HealthFacilityPicker"
                 district={district}


### PR DESCRIPTION
# Description

Improve the Health Facility Level field in the First Service Point panel when creating an insured person.
Currently, the field is too narrow, making it difficult to read the field label and affecting the overall user experience

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1200" height="160" alt="Screenshot 2026-07-07 at 4 34 07 PM" src="https://github.com/user-attachments/assets/fbab44ff-f9e1-4d38-b3d7-530ced660bf7" />
<img width="1425" height="361" alt="Screenshot 2026-07-09 at 5 30 27 PM" src="https://github.com/user-attachments/assets/d7cc83aa-d3cf-47a9-894e-1c756dc9ffac" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
