### PR TITLE
improve healthfacility form

### DIFF
--- a/src/components/HealthFacilityMasterPanel.jsx
+++ b/src/components/HealthFacilityMasterPanel.jsx
@@ -8,6 +8,7 @@ import {
   TextAreaInput,
   withModulesManager,
   ValidatedTextInput,
+  GRID_RESPONSIVE_SMALL,
 } from "@openimis/fe-core";
 import { Grid } from "@mui/material";
 import { connect } from "react-redux";
@@ -233,7 +234,8 @@ class HealthFacilityMasterPanel extends FormPanel {
               module="location"
               label="HealthFacilityForm.address"
               value={edited.address}
-              rows="2"
+              minRows="1"
+              maxRows="3"
               readOnly={readOnly}
               onChange={(v, s) => this.updateAttribute("address", v)}
             />
@@ -242,7 +244,7 @@ class HealthFacilityMasterPanel extends FormPanel {
             module="location"
             id="HealthFacility.phone"
             field={
-              <Grid size={1} className="item">
+              <Grid size={GRID_RESPONSIVE_SMALL} className="item">
                 <TextInput
                   module="location"
                   label="HealthFacilityForm.phone"


### PR DESCRIPTION
# Description

We adjust adress field to take 1 row in TextInputArea. The text go to the next line automatically
fix phone field size to GRID_RESPONSIVE_SMALL

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1200" height="318" alt="Screenshot 2026-07-07 at 5 20 30 PM" src="https://github.com/user-attachments/assets/3333f7b3-e840-47a2-adad-6bdd2d779f91" />
<img width="1334" height="345" alt="Screenshot 2026-07-09 at 6 01 50 PM" src="https://github.com/user-attachments/assets/15bed859-a0a0-46e1-8cc3-ed639a88aec1" />
<img width="1320" height="362" alt="Screenshot 2026-07-09 at 6 02 02 PM" src="https://github.com/user-attachments/assets/ee31474a-2a09-4d47-842a-b80a30c187a2" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
